### PR TITLE
fix: 폴더 이름에 예약어는 못 들어가서 폴더 이름 수정함

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
       "js"
     ],
     "testMatch": [
-      "**/__tests__/**/*.js",
+      "**/tests/**/*.js",
       "**/?(*.)+(spec|test).js"
     ],
     "transform": {


### PR DESCRIPTION
## Summary
폴더 이름에 __ 는 예약어라서 쓸 수 없는 문제 해결
close #

## Describe
__tests__ 에서 __는 예약어라 폴더 이름으로 쓸 수 없음, 그래서 tests로 폴더 이름을 수정함.

## Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] No new warnings

## Additional Notes & Screenshots

## Reference
